### PR TITLE
Redirect Dashboard logout to signup

### DIFF
--- a/src/Auth/Dashboard.js
+++ b/src/Auth/Dashboard.js
@@ -149,7 +149,7 @@ const Dashboard = () => {
           unsubscribePrompts();
         };
       } else {
-        navigate('/login'); // Redirect to login if not authenticated
+        navigate('/signup'); // Redirect to signup if not authenticated
       }
     });
 
@@ -159,7 +159,7 @@ const Dashboard = () => {
   const handleLogout = async () => {
     try {
       await signOut(auth);
-      navigate('/login'); // Redirect to login after logout
+      navigate('/signup'); // Redirect to signup after logout
     } catch (err) {
       console.error('Error signing out:', err);
       setError('Failed to log out.');


### PR DESCRIPTION
## Summary
- Redirect unauthenticated and post-logout flows from Dashboard to `/signup`

## Testing
- `npm test -- --watchAll=false`
- `npm start` & `curl -I http://localhost:3000/signup`


------
https://chatgpt.com/codex/tasks/task_e_6897fe4788f8832da6e305de255047a0